### PR TITLE
List workflows multiple namespaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@koreo/koreo-ts",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "type": "module",
   "description": "Typescript library for Koreo",
   "main": "dist/index.ts",

--- a/src/api/managed-resources.ts
+++ b/src/api/managed-resources.ts
@@ -18,6 +18,10 @@ export const parseManagedResources = (
         ]
       : managedResourcesStringOrParent;
 
+  if (!managedResourcesString) {
+    return { workflow: "", resources: {} };
+  }
+
   try {
     const parsed = JSON.parse(managedResourcesString);
     return parsed;


### PR DESCRIPTION
Support listing workflows across multiple namespaces.

Also fix a bug in parseManagedResources where cases where the managed-resources annotation missing weren't being handled properly.