### PR TITLE
Richer type info on InflatedNodes and managed resources

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@koreo/koreo-ts",
-  "version": "0.0.10",
+  "version": "1.0.0",
   "type": "module",
   "description": "Typescript library for Koreo",
   "main": "dist/index.ts",

--- a/src/api/graphs.ts
+++ b/src/api/graphs.ts
@@ -326,15 +326,12 @@ const addManagedResource = async (
   parentNode: ResourceFunctionNode
 ) => {
   const k8sResource = await getKubernetesResource(managedResource);
-  if (!k8sResource) {
-    return;
-  }
   if (!parentNode.managedResources) {
     parentNode.managedResources = [];
   }
   const resource = {
+    definition: managedResource,
     resource: k8sResource,
-    readonly: managedResource.readonly,
   };
   parentNode.managedResources.push(resource);
 };

--- a/src/api/inflated-graphs.ts
+++ b/src/api/inflated-graphs.ts
@@ -62,7 +62,20 @@ const convertGraph = (
     edges: {},
   };
   koreoGraph.nodes.forEach((knode) => {
-    if (knode.type === "SubWorkflow") {
+    if (knode.type === "Workflow") {
+      const node: InflatedNode = {
+        id: knode.id,
+        label: knode.metadata?.label
+          ? (knode.metadata.label as string)
+          : knode.krm.metadata?.name!,
+        type: {
+          isKoreoType: true,
+          name: "Workflow",
+        },
+        krm: knode.krm,
+      };
+      graph.nodes[node.id] = node;
+    } else if (knode.type === "SubWorkflow") {
       if (!knode.workflowGraph.nodes) {
         return;
       }
@@ -72,7 +85,10 @@ const convertGraph = (
         label: workflowNode.metadata?.label
           ? (workflowNode.metadata.label as string)
           : workflowNode.krm.metadata?.name!,
-        type: "Sub-Workflow",
+        type: {
+          isKoreoType: true,
+          name: "SubWorkflow",
+        },
         krm: workflowNode.krm,
       };
       graph.nodes[node.id] = node;
@@ -97,7 +113,10 @@ const convertGraph = (
         label: knode.metadata?.label
           ? (knode.metadata.label as string)
           : "RefSwitch",
-        type: "RefSwitch",
+        type: {
+          isKoreoType: true,
+          name: "RefSwitch",
+        },
       };
       graph.nodes[node.id] = node;
       if (includeResources) {
@@ -109,13 +128,29 @@ const convertGraph = (
         label: knode.metadata?.label
           ? (knode.metadata.label as string)
           : knode.krm.metadata?.name!,
-        type: knode.krm.kind!,
+        type: {
+          isKoreoType: true,
+          name: "ResourceFunction",
+        },
         krm: knode.krm,
       };
       graph.nodes[node.id] = node;
       if (includeResources) {
         addResourceNodes(graph, node.id, knode.managedResources);
       }
+    } else if (knode.type === "ValueFunction") {
+      const node: InflatedNode = {
+        id: knode.id,
+        label: knode.metadata?.label
+          ? (knode.metadata.label as string)
+          : knode.krm.metadata?.name!,
+        type: {
+          isKoreoType: true,
+          name: "ValueFunction",
+        },
+        krm: knode.krm,
+      };
+      graph.nodes[node.id] = node;
     } else if (knode.type === "Parent") {
       // Use a special id in case the parent is also a managed resource to avoid cycles
       const parentNodeId = `parent-${knode.id}`;
@@ -124,7 +159,10 @@ const convertGraph = (
         label: knode.metadata?.label
           ? (knode.metadata.label as string)
           : knode.krm.metadata?.name!,
-        type: knode.krm.kind!,
+        type: {
+          isKoreoType: false,
+          name: knode.krm.kind!,
+        },
         krm: knode.krm,
       };
       graph.nodes[node.id] = node;
@@ -134,16 +172,6 @@ const convertGraph = (
       if (parentEdge) {
         parentEdge.source = parentNodeId;
       }
-    } else {
-      const node: InflatedNode = {
-        id: knode.id,
-        label: knode.metadata?.label
-          ? (knode.metadata.label as string)
-          : knode.krm.metadata?.name!,
-        type: knode.krm.kind!,
-        krm: knode.krm,
-      };
-      graph.nodes[node.id] = node;
     }
   });
   koreoGraph.edges.forEach((kedge) => {
@@ -166,7 +194,20 @@ const convertGraphExpanded = (
   };
   const workflowLeafNodes: Record<string, string[]> = {};
   koreoGraph.nodes.forEach((knode) => {
-    if (knode.type === "SubWorkflow") {
+    if (knode.type === "Workflow") {
+      const node: InflatedNode = {
+        id: knode.id,
+        label: knode.metadata?.label
+          ? (knode.metadata.label as string)
+          : knode.krm.metadata?.name!,
+        type: {
+          isKoreoType: true,
+          name: "Workflow",
+        },
+        krm: knode.krm,
+      };
+      graph.nodes[node.id] = node;
+    } else if (knode.type === "SubWorkflow") {
       if (!knode.workflowGraph.nodes) {
         return;
       }
@@ -194,7 +235,10 @@ const convertGraphExpanded = (
       const switchInNode: InflatedNode = {
         id: switchInNodeId,
         label: switchInName,
-        type: "RefSwitch",
+        type: {
+          isKoreoType: true,
+          name: "RefSwitch",
+        },
       };
       graph.nodes[switchInNode.id] = switchInNode;
       const functionCaseNodes: string[] = [];
@@ -221,10 +265,23 @@ const convertGraphExpanded = (
             leafNodes: caseNode.workflowLeafNodeIds,
           });
         } else {
+          const isKoreoType =
+            caseNode.krm.kind! === "ResourceFunction" ||
+            caseNode.krm.kind! === "ValueFunction";
           const node: InflatedNode = {
             id: caseNode.id,
             label: `case: ${caseStr}`,
-            type: caseNode.krm.kind!,
+            type: isKoreoType
+              ? {
+                  isKoreoType: true,
+                  name: caseNode.krm.kind! as
+                    | "ResourceFunction"
+                    | "ValueFunction",
+                }
+              : {
+                  isKoreoType: false,
+                  name: caseNode.krm.kind!,
+                },
             krm: caseNode.krm,
           };
           graph.nodes[node.id] = node;
@@ -239,7 +296,10 @@ const convertGraphExpanded = (
       const switchOutNode: InflatedNode = {
         id: switchOutNodeId,
         label: switchOutName,
-        type: "RefSwitch Result",
+        type: {
+          isKoreoType: true,
+          name: "RefSwitchResult",
+        },
       };
       graph.nodes[switchOutNode.id] = switchOutNode;
       if (includeResources) {
@@ -293,13 +353,29 @@ const convertGraphExpanded = (
         label: knode.metadata?.label
           ? (knode.metadata.label as string)
           : knode.krm.metadata?.name!,
-        type: knode.krm.kind!,
+        type: {
+          isKoreoType: true,
+          name: "ResourceFunction",
+        },
         krm: knode.krm,
       };
       graph.nodes[node.id] = node;
       if (includeResources) {
         addResourceNodes(graph, node.id, knode.managedResources);
       }
+    } else if (knode.type === "ValueFunction") {
+      const node: InflatedNode = {
+        id: knode.id,
+        label: knode.metadata?.label
+          ? (knode.metadata.label as string)
+          : knode.krm.metadata?.name!,
+        type: {
+          isKoreoType: true,
+          name: "ValueFunction",
+        },
+        krm: knode.krm,
+      };
+      graph.nodes[node.id] = node;
     } else if (knode.type === "Parent") {
       // Use a special id in case the parent is also a managed resource to avoid cycles
       const parentNodeId = `parent-${knode.id}`;
@@ -308,7 +384,10 @@ const convertGraphExpanded = (
         label: knode.metadata?.label
           ? (knode.metadata.label as string)
           : knode.krm.metadata?.name!,
-        type: knode.krm.kind!,
+        type: {
+          isKoreoType: false,
+          name: knode.krm.kind!,
+        },
         krm: knode.krm,
       };
       graph.nodes[node.id] = node;
@@ -318,16 +397,6 @@ const convertGraphExpanded = (
       if (parentEdge) {
         parentEdge.source = parentNodeId;
       }
-    } else {
-      const node: InflatedNode = {
-        id: knode.id,
-        label: knode.metadata?.label
-          ? (knode.metadata.label as string)
-          : knode.krm.metadata?.name!,
-        type: knode.krm.kind!,
-        krm: knode.krm,
-      };
-      graph.nodes[node.id] = node;
     }
   });
 

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -124,6 +124,6 @@ export type ParentNode = {
 };
 
 export type ManagedKubernetesResource = {
-  resource: KubernetesObjectWithSpecAndStatus;
-  readonly: boolean;
+  definition: KubernetesResource;
+  resource: KubernetesObjectWithSpecAndStatus | null;
 };

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -38,8 +38,7 @@ export type NodeType =
   | "ValueFunction"
   | "ResourceFunction"
   | "RefSwitch"
-  | "SubWorkflow"
-  | "ManagedResource";
+  | "SubWorkflow";
 
 export type EdgeType =
   | "ParentToWorkflow"

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -1,11 +1,28 @@
 import { KubernetesObjectWithSpecAndStatus } from "./kubernetes";
 import { ValueFunction, ResourceFunction } from "./function";
 import { WorkflowParent, Workflow } from "./workflow";
+import { KubernetesResource } from "./managed-resource";
+
+export type KoreoType = {
+  isKoreoType: true;
+  name:
+    | "Workflow"
+    | "SubWorkflow"
+    | "RefSwitch"
+    | "RefSwitchResult"
+    | "ResourceFunction"
+    | "ValueFunction";
+};
+
+export type NonKoreoType = {
+  isKoreoType: false;
+  name: string;
+};
 
 export type InflatedNode = {
   id: string;
   label: string;
-  type: string;
+  type: KoreoType | NonKoreoType;
   krm?: KubernetesObjectWithSpecAndStatus;
   metadata?: Record<string, unknown>;
 };


### PR DESCRIPTION
Introduces a breaking change to inflated graphs to provide richer type information on the nodes (i.e. information to let us know if a node is a "Koreo type" (Workflow, ValueFunction, ResourceFunction, etc.) or a "non-Koreo type" (any non-Koreo KRM).

Additionally, include the resource definition on managed resources in addition to the resource KRM itself and make the KRM nullable. This allows us to know if a managed resource is _expected_ (and what kind of resource is expected) but not actually present in the cluster for some reason.

Bumped version to 1.0.0 due to breaking API changes.